### PR TITLE
Snail climb algorithm improvements

### DIFF
--- a/exercises/snail/snail.js
+++ b/exercises/snail/snail.js
@@ -1,17 +1,22 @@
-var triesToClimb = 7;
-var slide = 2;
-
-var climbPerDay = triesToClimb - slide;
-
-var daysCount = 0;
-
 const climb = (stepsToClimb) => {
 
-    for (step = triesToClimb, days = 1; step < stepsToClimb; step += triesToClimb, days++) {
-        step -= slide;
+    var climbStepsPerDay = 7;
+    var slideStepsPerDay = 2;
+    var daysCount = 0;
+
+    for (step = 0; step <= stepsToClimb;) {
+
+        step += climbStepsPerDay
+        daysCount++;
+
+        if (step >= stepsToClimb) {
+            break;
+        }
+
+        step -= slideStepsPerDay;
     }
 
-    return days;
+    return daysCount;
 }
 
 exports.climb = climb;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "snail",
+  "name": "sololearn-javascript-exercises",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "snail",
+      "name": "sololearn-javascript-exercises",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
The code was broking because of this instruction: `step += climbStepsPerDay`
It cannot be in the 3rd for loop statement because there, this code is executed at the end of a iteration and it must be executed at the beginning of the iteration.
@ma-oliveiramarques 